### PR TITLE
Turned off Dockerfile maven plugin Google Container Registry support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install: skip
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - mvn --batch-mode clean package
+  - mvn --batch-mode clean package -Ddockerfile.googleContainerRegistryEnabled=false
   - docker images
 
 deploy:


### PR DESCRIPTION
Turned off Dockerfile maven plugin Google Container Registry support for Travis CI to eliminate build warnings